### PR TITLE
Fix import casing to match kebab filenames

### DIFF
--- a/src/cli/bundle-command.ts
+++ b/src/cli/bundle-command.ts
@@ -5,7 +5,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { BundleModule } from '../modules/bundle-module';
-import { CriticalError, PipelineValidator } from '../utils/CriticalError';
+import { CriticalError, PipelineValidator } from '../utils/critical-error';
 import { logger } from '../utils/logger';
 
 export async function executeBundleCommand(options: {

--- a/src/cli/collection-command.ts
+++ b/src/cli/collection-command.ts
@@ -9,7 +9,7 @@ import type {
   CollectionCLIOptions,
   PipelineSourceType,
 } from '../types/pipeline';
-import { CriticalError, PipelineValidator } from '../utils/CriticalError';
+import { CriticalError, PipelineValidator } from '../utils/critical-error';
 import { logger } from '../utils/logger';
 import type { PipelineState } from '../utils/pipeline-state-manager';
 

--- a/src/cli/discovery-command.ts
+++ b/src/cli/discovery-command.ts
@@ -9,7 +9,7 @@ import type {
   DiscoveryCLIOptions,
   PipelineSourceType,
 } from '../types/pipeline';
-import { CriticalError, PipelineValidator } from '../utils/CriticalError';
+import { CriticalError, PipelineValidator } from '../utils/critical-error';
 import { logger } from '../utils/logger';
 
 export async function executeDiscoveryCommand(options: DiscoveryCLIOptions) {

--- a/src/cli/distillation-command.ts
+++ b/src/cli/distillation-command.ts
@@ -9,7 +9,7 @@ import type {
   DistillationCLIOptions,
   PipelineSourceType,
 } from '../types/pipeline';
-import { CriticalError, PipelineValidator } from '../utils/CriticalError';
+import { CriticalError, PipelineValidator } from '../utils/critical-error';
 import { logger } from '../utils/logger';
 import type { PipelineState } from '../utils/pipeline-state-manager';
 

--- a/src/cli/orchestration-command.ts
+++ b/src/cli/orchestration-command.ts
@@ -22,9 +22,9 @@ import type {
   PipelineStateWithPackageResult,
   ProgressCallback,
 } from '../types/pipeline';
-import { CriticalError, PipelineValidator } from '../utils/CriticalError';
+import { CriticalError, PipelineValidator } from '../utils/critical-error';
 import { logger } from '../utils/logger';
-import { PipelineStateManager } from '../utils/PipelineStateManager';
+import { PipelineStateManager } from '../utils/pipeline-state-manager';
 
 /**
  * Interactive orchestration class

--- a/src/cli/package-command.ts
+++ b/src/cli/package-command.ts
@@ -6,7 +6,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { PackageModule } from '../modules/package-module';
 import type { PackageCLIOptions, PipelineSourceType } from '../types/pipeline';
-import { CriticalError, PipelineValidator } from '../utils/CriticalError';
+import { CriticalError, PipelineValidator } from '../utils/critical-error';
 import { logger } from '../utils/logger';
 import type { PipelineState } from '../utils/pipeline-state-manager';
 

--- a/src/modules/collection-module.ts
+++ b/src/modules/collection-module.ts
@@ -20,7 +20,7 @@ import path from 'node:path';
 import { request } from 'undici';
 import type { PipelineSourceType } from '../types/pipeline';
 import { logger } from '../utils/logger';
-import type { PipelineState } from '../utils/PipelineStateManager';
+import type { PipelineState } from '../utils/pipeline-state-manager';
 import { CollectionStats } from './collection/collection-stats';
 
 /**

--- a/src/modules/package-module.ts
+++ b/src/modules/package-module.ts
@@ -16,7 +16,7 @@ import crypto from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { logger } from '../utils/logger';
-import type { PipelineState } from '../utils/PipelineStateManager';
+import type { PipelineState } from '../utils/pipeline-state-manager';
 import { ContentProcessor } from './packaging/content-processor';
 import { CrossReferenceAnalyzer } from './packaging/cross-reference-analyzer';
 import { PackageStats } from './packaging/package-stats';


### PR DESCRIPTION
## Summary
- fix leftover import statements that still referenced the old `CamelCase` file names

## Testing
- `bun run lint` *(fails: some existing lint errors)*
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68769dff53108331a5076f57ef0fae2b