### PR TITLE
Add distillation timeout option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,9 @@ bun src/index.ts package
 
 # Bundle for distribution
 bun src/index.ts bundle
+
+# Orchestrate the entire pipeline interactively
+bun src/index.ts orchestrate --distill-timeout 600000
 ```
 
 ## Generated Output

--- a/src/cli/orchestration-command.ts
+++ b/src/cli/orchestration-command.ts
@@ -670,7 +670,7 @@ export class OrchestrationCommand {
       outputDirectory: './generated/distilled-content',
       geminiModel: options.geminiModel || 'gemini-2.5-flash',
       maxConcurrentDistillations: 1,
-      timeout: 600_000,
+      timeout: Number.parseInt(options.distillTimeout || '600000', 10),
     });
 
     const results = await distillation.distill(sourcesData);
@@ -813,7 +813,7 @@ export class OrchestrationCommand {
       outputDirectory: './generated/distilled-content',
       geminiModel: options.geminiModel || 'gemini-2.5-flash',
       maxConcurrentDistillations: 1,
-      timeout: Number.parseInt(options.timeout || '600000', 10),
+      timeout: Number.parseInt(options.distillTimeout || '600000', 10),
       progressCallback: (
         current: number,
         total: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,11 @@ program
   .option('--timeout <ms>', 'Request timeout in milliseconds', '30000')
   .option('--max-concurrent <num>', 'Maximum concurrent operations', '3')
   .option('--gemini-model <model>', 'Gemini model to use', 'gemini-2.5-flash')
+  .option(
+    '--distill-timeout <ms>',
+    'Processing timeout for distillation',
+    '600000'
+  )
   .option('--bundle-name <name>', 'Bundle name prefix', 'porter-bridges')
   .option(
     '--version <version>',

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -86,6 +86,7 @@ export interface OrchestrationCLIOptions {
   skipDistillation?: boolean;
   cacheDir?: string;
   timeout?: string;
+  distillTimeout?: string;
   maxConcurrent?: string;
   geminiModel?: string;
   version?: string;


### PR DESCRIPTION
## Summary
- extend `OrchestrationCLIOptions` with `distillTimeout`
- allow specifying `--distill-timeout` in the orchestrate command
- honor new option when running distillation steps
- document interactive orchestration and timeout option

## Testing
- `bun install`
- `bun run lint` *(fails: ultracite command not found)*
- `bun run build` *(fails: type errors in project)*
- `bun run format` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876e9582fb08331be9a5077c79a3790