### PR TITLE
Use mdream before distillation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "commander": "^11.0.0",
         "ky": "^1.8.1",
         "listr2": "^8.0.1",
+        "mdream": "^0.8.0",
         "ora": "^8.0.1",
         "remeda": "^2.25.0",
         "undici": "^7.11.0",
@@ -337,6 +338,8 @@
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
+    "mdream": ["mdream@0.8.0", "", { "dependencies": { "cac": "^6.7.14", "pathe": "^2.0.3", "tinyglobby": "^0.2.14" }, "bin": { "mdream": "bin/mdream.mjs" } }, "sha512-3NYUp2moh5DUqRf9wLw7gnMCDjY0wKCFl+w/s9gcSeNXLTV6xOJ+s0ZLVoRnt3nPHVsROKHjeEOxw/BpNFIc2A=="],
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ generated/
 ├── collected-sources.json     # Collection metadata
 ├── distilled-content/         # AI-extracted JSON
 ├── distilled-sources.json     # Distillation metadata
+├── trash/                     # Invalid files for manual review
 ├── packages/                  # Versioned packages
 ├── package-results.json       # Package metadata
 ├── bundles/                   # Distribution bundles
@@ -62,6 +63,7 @@ generated/
 - **zod** - Schema validation (we love Zod!)
 - **fs** - Native Node.js file operations
 - **Simple logging** - No external logger dependencies
+- **mdream** - HTML → Markdown conversion for AI processing
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "remeda": "^2.25.0",
     "undici": "^7.11.0",
     "winston": "^3.17.0",
-    "zod": "^4.0.5"
+    "zod": "^4.0.5",
+    "mdream": "^0.8.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.1",


### PR DESCRIPTION
## Summary
- add dependency `mdream`
- document `trash/` folder for bad Gemini output
- import mdream minimal preset directly
- move invalid Gemini output files to `generated/trash` instead of deleting

## Testing
- `bun run format` *(fails: lint errors)*
- `bun run lint` *(fails: lint errors)*
- `bun run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876f5f6cbd883318ca95202bdfdda7c